### PR TITLE
Use cl-loop instead of loop

### DIFF
--- a/helm-xref.el
+++ b/helm-xref.el
@@ -71,20 +71,20 @@ Use FUNC to display buffer."
     :candidate-transformer (lambda (candidates)
                              (let (group
                                    result)
-                               (loop for x in (reverse (cl-sort candidates #'string-lessp :key #'car))
-                                     do (cond
-                                         ((or (= (length group) 0)
-                                              (string= (nth 0 (split-string (car x) ":"))
-                                                       (nth 0 (split-string (car (nth -1 group)) ":"))))
-                                          (push x group))
-                                         (t
-                                          (dolist (xref (cl-sort group #'> :key #'cdr))
-                                            (push xref result))
-                                          (setq group nil)
-                                          (push x group)))
-                                     finally (when (> (length group) 0)
-                                               (dolist (xref (cl-sort group #'> :key #'cdr))
-                                                 (push xref result))))
+                               (cl-loop for x in (reverse (cl-sort candidates #'string-lessp :key #'car))
+					do (cond
+					    ((or (= (length group) 0)
+						 (string= (nth 0 (split-string (car x) ":"))
+							  (nth 0 (split-string (car (nth -1 group)) ":"))))
+					     (push x group))
+					    (t
+					     (dolist (xref (cl-sort group #'> :key #'cdr))
+					       (push xref result))
+					     (setq group nil)
+					     (push x group)))
+					finally (when (> (length group) 0)
+						  (dolist (xref (cl-sort group #'> :key #'cdr))
+						    (push xref result))))
                                result))
     :candidate-number-limit 9999))
 


### PR DESCRIPTION
I use Emacs 25.2, loop macro is not defined by default.