### PR TITLE
Allow file paths to be shown in xref-buffer

### DIFF
--- a/helm-xref.el
+++ b/helm-xref.el
@@ -25,6 +25,9 @@
 (require 'xref)
 (require 'cl-seq)
 
+(defvar helm-xref-candidate-formatting-function 'helm-xref-format-candidate-short
+  "Select the function for candidate formatting.")
+
 (defvar helm-xref-alist nil
   "Holds helm candidates.")
 
@@ -50,17 +53,34 @@
              (file (xref-location-group location))
              candidate)
         (setq candidate
-              (concat
-               (propertize file 'font-lock-face 'helm-xref-file-name)
-               (when (string= "integer" (type-of line))
-                 (concat
-                  "\n:"
-                  (propertize (int-to-string line)
-                              'font-lock-face 'helm-xref-line-number)))
-               ":"
-               summary))
+              (funcall helm-xref-candidate-formatting-function file line summary))
         (push (cons candidate xref) helm-xref-alist))))
   (setq helm-xref-alist (reverse helm-xref-alist)))
+
+(defun helm-xref-format-candidate-short (file line summary)
+  "Build short form of candidate format with FILE, LINE, and SUMMARY."
+  (concat
+   (propertize (car (reverse (split-string file "\\/")))
+	       'font-lock-face 'helm-xref-file-name)
+   (when (string= "integer" (type-of line))
+     (concat
+      ":"
+      (propertize (int-to-string line)
+		  'font-lock-face 'helm-xref-line-number)))
+   ":"
+   summary))
+
+(defun helm-xref-format-candidate-long (file line summary)
+  "Build long form of candidate format with FILE, LINE, and SUMMARY."
+  (concat
+   (propertize file 'font-lock-face 'helm-xref-file-name)
+   (when (string= "integer" (type-of line))
+     (concat
+      "\n:"
+      (propertize (int-to-string line)
+		  'font-lock-face 'helm-xref-line-number)))
+   ":"
+   summary))
 
 (defun helm-xref-goto-xref-item (xref-item func)
   "Set buffer and point according to xref-item XREF-ITEM.

--- a/helm-xref.el
+++ b/helm-xref.el
@@ -54,7 +54,7 @@
                (propertize file 'font-lock-face 'helm-xref-file-name)
                (when (string= "integer" (type-of line))
                  (concat
-                  ":"
+                  "\n:"
                   (propertize (int-to-string line)
                               'font-lock-face 'helm-xref-line-number)))
                ":"
@@ -92,7 +92,7 @@ Needs to be set the value of `xref-show-xrefs-function'."
   (setq helm-xref-alist nil)
   (helm-xref-candidates xrefs)
   (helm :sources (helm-xref-source)
-        :truncate-lines f
+        :truncate-lines t
         :buffer "*helm-xref*"))
 
 (provide 'helm-xref)

--- a/helm-xref.el
+++ b/helm-xref.el
@@ -25,9 +25,6 @@
 (require 'xref)
 (require 'cl-seq)
 
-(defvar helm-xref-candidate-formatting-function 'helm-xref-format-candidate-short
-  "Select the function for candidate formatting.")
-
 (defvar helm-xref-alist nil
   "Holds helm candidates.")
 
@@ -44,6 +41,13 @@
   '((t (:inherit 'compilation-line-number)))
   "Face for xref line number"
   :group 'helm-xref)
+
+(defcustom  helm-xref-candidate-formatting-function 'helm-xref-format-candidate-short
+  "Select the function for candidate formatting."
+  :type '(radio (function-item helm-xref-format-candidate-short)
+		(function-item helm-xref-format-candidate-long)
+		function))
+  :group 'helm-xref
 
 (defun helm-xref-candidates (xrefs)
   "Convert XREF-ALIST items to helm candidates and add them to `helm-xref-alist'."

--- a/helm-xref.el
+++ b/helm-xref.el
@@ -51,8 +51,7 @@
              candidate)
         (setq candidate
               (concat
-               (propertize (car (reverse (split-string file "\\/")))
-                           'font-lock-face 'helm-xref-file-name)
+               (propertize file 'font-lock-face 'helm-xref-file-name)
                (when (string= "integer" (type-of line))
                  (concat
                   ":"
@@ -93,7 +92,7 @@ Needs to be set the value of `xref-show-xrefs-function'."
   (setq helm-xref-alist nil)
   (helm-xref-candidates xrefs)
   (helm :sources (helm-xref-source)
-        :truncate-lines t
+        :truncate-lines f
         :buffer "*helm-xref*"))
 
 (provide 'helm-xref)


### PR DESCRIPTION
In cases where file names repeat in different directories, we need to be able to distinguish one from another in the xref-buffer.  Since helm-xref, trims the path from the file, we can't tell which file is which.

By showing the full path and adding a "\n" between _file_ and _line_, we get the a layout similar to the default `xref--show-xref-buffer`, which puts _line_ and _summary_ on their own line below the _file_.

This allows for the important path information to be seen when displaying xref results.