### PR TITLE
Set xref-show-definitions function

### DIFF
--- a/helm-xref.el
+++ b/helm-xref.el
@@ -166,8 +166,10 @@ Needs to be set the value of `xref-show-xrefs-function'."
         :buffer "*helm-xref*"))
 
 (if (< emacs-major-version 27)
-    (setq xref-show-xrefs-function 'helm-xref-show-xrefs)
-  (setq xref-show-xrefs-function 'helm-xref-show-xrefs-27))
+      (setq xref-show-xrefs-function 'helm-xref-show-xrefs)
+    (progn
+       (setq xref-show-xrefs-function 'helm-xref-show-xrefs-27)
+       (setq xref-show-definitions-function 'helm-xref-show-xrefs-27)))
 
 (provide 'helm-xref)
 ;;; helm-xref.el ends here


### PR DESCRIPTION
With the current code if you use `(xref-show-definitions)` you'll see that is not using helm-xref. This PR sets the definitions function as well so you have the same look and feel 